### PR TITLE
Manufacturer data may be larger

### DIFF
--- a/lib/bleacon.js
+++ b/lib/bleacon.js
@@ -70,7 +70,7 @@ Bleacon.prototype.onDiscover = function(peripheral) {
   debug('onDiscover: manufacturerData = %s, rssi = %d', manufacturerData ?  manufacturerData.toString('hex') : null, rssi);
 
   if (manufacturerData && 
-      EXPECTED_MANUFACTURER_DATA_LENGTH === manufacturerData.length &&
+      EXPECTED_MANUFACTURER_DATA_LENGTH <= manufacturerData.length &&
       APPLE_COMPANY_IDENTIFIER === manufacturerData.readUInt16LE(0) &&
       IBEACON_TYPE === manufacturerData.readUInt8(2) &&
       EXPECTED_IBEACON_DATA_LENGTH === manufacturerData.readUInt8(3)) {


### PR DESCRIPTION
Manufacturer data may contain additional info like battery level. Size should be at least 25, not strictly 25.
easiBeacon for example does this:

> 04 3E 2B 02 01 03 01 CE 11 AD 42 85 F7 1F 02 01 04 1B FF 4C 
  00 02 15 A7 AE 2E B7 1F 00 41 68 B9 9B A7 49 BA C1 CA 64 00 
  01 00 01 BB 4E B9