### PR TITLE
Updating bignum dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "noble": "~0.3.0",
     "debug": "~0.7.2",
     "bleno": "~0.1.0",
-    "bignum": "~0.6.2"
+    "bignum": "~0.9.2"
   },
   "devDependencies": {
     "jshint": "~2.1.11",


### PR DESCRIPTION
Depending on the latest version of bignum allows bleacon to work on a Raspberry Pi.

Setup:
Raspberry Pi B+
Node.js 0.12.0