### PR TITLE
Adds beacon uuid to motionStateChange event.

### DIFF
--- a/estimote/README.md
+++ b/estimote/README.md
@@ -105,7 +105,7 @@ estimote.readTemperature(callback(error, temperature));
 
 estimote.subscribeMotion(callback(error));
 estimote.unsubscribeMotion(callback(error));
-estimote.on('motionStateChange', callback(isMoving));
+estimote.on('motionStateChange', callback(isMoving, uuid));
 ```
 
 Events

--- a/estimote/estimote.js
+++ b/estimote/estimote.js
@@ -310,7 +310,7 @@ Estimote.prototype.unsubscribeMotion = function(callback) {
 };
 
 Estimote.prototype.onMotionData = function(data) {
-  this.emit('motionStateChange', data.readUInt8(0) ? true : false);
+  this.emit('motionStateChange', data.readUInt8(0) ? true : false, this.uuid);
 };
 
 Estimote.prototype.readService2_9 = function(callback) {

--- a/estimote/test.js
+++ b/estimote/test.js
@@ -10,8 +10,8 @@ Estimote.discover(function(estimote) {
         process.exit(0);
       });
 
-      estimote.on('motionStateChange', function(isMoving) {
-        console.log('\tmotion state change: isMoving = ' + isMoving);
+      estimote.on('motionStateChange', function(isMoving, uuid) {
+        console.log('\tmotion state change for ' + uuid +': isMoving = ' + isMoving);
       });
 
       console.log('found: ' + estimote.toString());


### PR DESCRIPTION
One feature that I felt was really lacking was the ability to identify which beacon detected movement since this allows for more flexibility while developing.

I added the UUID to the `motionStateChange` event, allowing to identify the beacon and interact with it. It was also possible to return the beacon instance, but this approach seems less intrusive.