### PR TITLE
Set the environment variable NOBLE_REPORT_ALL_HCI_EVENTS to 1

### DIFF
--- a/estimote-sticker/estimote-sticker.js
+++ b/estimote-sticker/estimote-sticker.js
@@ -5,6 +5,14 @@ var debug = require('debug')('estimote-sticker');
 
 var noble = require('noble');
 
+debug("NOBLE_REPORT_ALL_HCI_EVENTS env variable has to be set to 1");
+
+if(process.env['NOBLE_REPORT_ALL_HCI_EVENTS'] === undefined) {
+  process.env['NOBLE_REPORT_ALL_HCI_EVENTS'] = 1;
+}
+
+
+
 var EstimoteSticker = function() {
   noble.on('discover', this.onDiscover.bind(this));
 };


### PR DESCRIPTION
Fixes estimote-sticker detection while not in motion