### PR TITLE
Updates bignum version to 0.12.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/sandeepmistry/node-bleacon/issues"
   },
   "dependencies": {
-    "bignum": "^0.11.0",
+    "bignum": "^0.12.5",
     "bleno": "^0.4.1",
     "debug": "^2.2.0",
     "noble": "^1.7.0",


### PR DESCRIPTION
This is basically #81 without the forked repo. 